### PR TITLE
Typo fix in workspace help

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -92,7 +92,7 @@ const COLUMNS: &[&[Section]] = &[
                     Schema::Hardcoded(&["Super", "Shift", "↓"]),
                 ),
                 Shortcut::new(
-                    "Switch focus to the worksapce above",
+                    "Switch focus to the workspace above",
                     Event::MoveWorkspaceAbove,
                     Schema::Hardcoded(&["Super", "Ctrl", "↑"]),
                 ),


### PR DESCRIPTION
I noticed a typo in the shortcuts guide. This PR fixes it. 

Typo in action:
![image](https://user-images.githubusercontent.com/50179998/80810537-17436400-8b92-11ea-9840-f78bc9613ec0.png)

